### PR TITLE
Changed "python path location" to just "python"

### DIFF
--- a/run.bat
+++ b/run.bat
@@ -1,2 +1,2 @@
-"Path\to\your\python executable\python.exe" "Path\to\where\the\main.py\file\is\located\main.py"
+python "Path\to\where\the\main.py\file\is\located\main.py"
 pause


### PR DESCRIPTION
I did this because I assume everyone has  their python added to PATH so instead we can just add "python" and if they need to write "python3" you can specify it in the README